### PR TITLE
Added Jacoco to the pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -85,6 +85,25 @@
                     </excludes>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <version>0.8.8</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>prepare-agent</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>report</id>
+                        <phase>prepare-package</phase>
+                        <goals>
+                            <goal>report</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
     <profiles>


### PR DESCRIPTION
This adds Jacoco reports to the build, which can be picked up by SonarQube or other products to show how much of the code is covered by the current testing.